### PR TITLE
templates_c 以下の PHP ファイルを削除する機能を追加

### DIFF
--- a/addons/DynamicMTML.pack/config.yaml
+++ b/addons/DynamicMTML.pack/config.yaml
@@ -146,6 +146,11 @@ callbacks:
     MT::Category::post_remove: $dynamicmtml::DynamicMTML::Plugin::_cb_post_change
     MT::Folder::post_save: $dynamicmtml::DynamicMTML::Plugin::_cb_post_change
     MT::Folder::post_remove: $dynamicmtml::DynamicMTML::Plugin::_cb_post_change
+upgrade_functions:
+    dynamicmtml_remove_compiled_template_files:
+        version_limit: 1.02
+        plugin: DynamicMTML
+        code: $dynamicmtml::DynamicMTML::Plugin::_remove_compiled_template_files
 tags:
     block:
         RawMTML: $dynamicmtml::DynamicMTML::Tags::_hdlr_raw_mtml

--- a/addons/DynamicMTML.pack/lib/DynamicMTML/L10N/ja.pm
+++ b/addons/DynamicMTML.pack/lib/DynamicMTML/L10N/ja.pm
@@ -28,6 +28,8 @@ our %Lexicon = (
     'Error: Movable Type cannot write to the search cache directory.<br />Please check the permissions for the directory called <code>[_1]</code>.'
         => 'クエリー付きリクエストのビルド結果をキャッシュするディレクトリを作成できません。<br /><code>[_1]</code>ディレクトリを作成してください。',
     'Removes old page cache.' => 'ページキャッシュの定期クリア',
+    'Removed the cache file.' => 'キャッシュファイルを削除しました。',
+    'Failed to remove cache file.' => 'キャッシュファイルを削除できませんでした。',
     );
 
 1;


### PR DESCRIPTION
DynamicMTML の仕様変更によりアップグレード前の PHP キャッシュファイルの破棄が必要なため、アップグレード時に削除を行います。